### PR TITLE
Fixed lineskips so that reading in the daymet file works again.

### DIFF
--- a/R/download_daymet.r
+++ b/R/download_daymet.r
@@ -179,20 +179,20 @@ download_daymet = function(site = "Daymet",
     # read ancillary data from downloaded file header
     # this includes, tile nr and altitude
     tile = as.numeric(scan(daymet_tmp_file,
-                           skip = 2,
+                           skip = 4,
                            nlines = 1,
                            what = character(),
                            quiet = TRUE)[2])
 
     alt = as.numeric(scan(daymet_tmp_file,
-                          skip = 3,nlines = 1,
+                          skip = 5,nlines = 1,
                           what = character(),
                           quiet = TRUE)[2])
 
     # read in the real climate data
     data = utils::read.table(daymet_tmp_file,
                       sep = ',',
-                      skip = 7,
+                      skip = 8,
                       header = TRUE)
 
     # put all data in a list

--- a/vignettes/daymetr-vignette.Rmd
+++ b/vignettes/daymetr-vignette.Rmd
@@ -73,8 +73,8 @@ The package maintains the original data header names in order to provide a trans
 ```{r fig.width = 7, fig.height=3}
 # simple graph of Daymet data
 par(mar=c(4,4,1,1))
-plot(as.Date(paste(df$data$year,
-                   df$data$yday,
+plot(as.Date(paste(df$data$YEAR,
+                   df$data$DAY,
                    sep = "-"),
              "%Y-%j"),
      df$data$tmax..deg.c.,


### PR DESCRIPTION
In order to be more robust to future changes, it would be good
to search the file for the header information (tile number,
elevation, data header) rather than assume a line number for it.