### PR TITLE
Fix CRS projection issue in vignette

### DIFF
--- a/vignettes/daymetr-vignette.Rmd
+++ b/vignettes/daymetr-vignette.Rmd
@@ -173,7 +173,7 @@ The above figure shows nicely how you can query a small subset of the Daymet dat
 r <- raster::stack(system.file(package = "daymetr","extdata/tmin_monavg_1980_ncss.nc"))
 
 # to set the correct projection use
-raster::projection(r) <- "+proj=lcc +lat_1=25 +lat_2=60 +lat_0=42.5 +lon_0=-100 +x_0=0 +y_0=0 +a=6378137 +b=6356752.314706705 +units=m +no_defs"
+raster::projection(r) <- "+proj=lcc +lat_1=25 +lat_2=60 +lat_0=42.5 +lon_0=-100 +x_0=0 +y_0=0 +a=6378137 +b=6356752.314706705 +units=km +no_defs"
 
 # reproject to lat lon
 r <- raster::projectRaster(r, crs = "+init=epsg:4326")


### PR DESCRIPTION
Dear Koen,
thanks for this fantastic package! I've found a little issue with re-projecting the gridded NetCDF files obtained via `daymetr::download_daymet_ncss()`. The units provided in this file differ from those of the tiled data sets (m vs. km; confirmed for daily and annual data), and hence the proj4string needs to be adjusted. See reprex below!

Cheers

``` r
library(daymetr) #github version

# read in the demo data from the package for speed
r <- raster::stack(system.file(package = "daymetr","extdata/tmin_monavg_1980_ncss.nc"))
#> Loading required namespace: ncdf4
#> Warning in .getCRSfromGridMap4(atts): cannot process these parts of the CRS:
#> _CoordinateTransformType=298.257223563
#> _CoordinateAxisTypes=Projection
#> Warning in cbind(m[i, ], vals): number of rows of result is not a multiple
#> of vector length (arg 2)

# set projection based on old vignette
raster::projection(r) <- "+proj=lcc +lat_1=25 +lat_2=60 +lat_0=42.5 +lon_0=-100 +x_0=0 +y_0=0 +a=6378137 +b=6356752.314706705 +units=m +no_defs"

# reproject to lat lon
r <- raster::projectRaster(r, crs = "+init=epsg:4326")

# plot the monthly mean minimum temperature for 1980
raster::plot(r)
```

![](https://i.imgur.com/ijyL3cB.png)

``` r

## Projected geographic lat/lon  coordinates to not align with actual site 
## (smoky mountain NP) at -85, 35

# Fix: change projection info to units of km, as listed in NC output:

nc <- ncdf4::nc_open(system.file(package = "daymetr","extdata/tmin_monavg_1980_ncss.nc"))
print(nc$dim$y$units)
#> [1] "km"


proj_lcc_km <- "+proj=lcc +lat_1=25 +lat_2=60 +lat_0=42.5 +lon_0=-100 +x_0=0 +y_0=0 +a=6378137 +b=6356752.314706705 +units=km +no_defs"



# read in the demo data from the package for speed
r <- raster::stack(system.file(package = "daymetr","extdata/tmin_monavg_1980_ncss.nc"))
#> Warning in .getCRSfromGridMap4(atts): cannot process these parts of the CRS:
#> _CoordinateTransformType=298.257223563
#> _CoordinateAxisTypes=Projection

#> Warning in .getCRSfromGridMap4(atts): number of rows of result is not a multiple of vector length (arg 2)

# to set the correct projection use
raster::projection(r) <- proj_lcc_km

# reproject to lat lon
r <- raster::projectRaster(r, crs = "+init=epsg:4326")

# plot the monthly mean minimum temperature for 1980
raster::plot(r)
```

![](https://i.imgur.com/mUoYFUL.png)

Created on 2019-03-29 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).